### PR TITLE
chore: Comply with the game's requested frame-rate.

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
                 document.body.innerHTML = `
                     <div class="not-hosted-msg">
                         <div class="important">
-                          <p>Unfortunately, due to CORs restrictions, the wasm assembly cannot be fetched.</p>
+                          <p>Unfortunately, due to CORS restrictions, the wasm assembly cannot be fetched.</p>
                           <p>Please navigate to this location using a web server.</p>
                           <p>If you have Python 3 on your system you can just do:</p>
                         </div>


### PR DESCRIPTION
By having a manual frame-loop we can control (with some inaccuracies) the frame-rate.
I chose to use `setTimeout` instead of `setInterval` for two reasons.

1. `setInterval` doesn't wait for the previous iteration to end (allowing for duplicate frames)
2. due to the nature of `setInterval`, I'd have to call `clearInterval` anytime the `targetFPS` is changed.
